### PR TITLE
Automatically suspend all applications out of focus

### DIFF
--- a/myAppNap.py
+++ b/myAppNap.py
@@ -1,72 +1,73 @@
-#!/usr/bin/python                                                                                            
+#!/usr/bin/python
 
-''' This script automatically finds PIDs for desiredApp
-    and suspend those processes whenever desired app  is not in focus. 
-    This script is meant to stay running and polls window focus every 1 second
-    On receiving keyboard interrupt, will resume
-'''
-from datetime import datetime
-from time import sleep
+from __future__ import print_function
+import time
 import sys
 import subprocess
 import os
 import signal
+import logging
 
 try:
-    from AppKit import NSWorkspace
+  from AppKit import NSWorkspace
 except ImportError:
-    print "Can't import AppKit -- maybe you're running python from brew?"
-    print "Try running with Apple's /usr/bin/python instead."
-    exit(1)
+  print("Can't import AppKit -- maybe you're running python from brew?")
+  print("Try running with Apple's /usr/bin/python instead.")
+  sys.exit(1)
 
-def get_pid(name):
-    try:
-        result = subprocess.check_output(['pgrep '+name], shell=True)
-        return result.strip().split('\n')
-    except:
-        print '''Invalid app name, will not suspend/resume anything
-        Will monitor apps in focus, switch to your desired app to see valid name'''
-        return None
 
-# if script invoked with an argument, use that as the pid
-desiredApp = 'asfjsadfjasdflkjasf'
-if len(sys.argv) > 1:
-    da = sys.argv[1]
-    if da == 'Terminal':
-        print 'Can\'t suspend Terminal, especially if you are calling from Terminal'
-    else:
-        desiredApp = da
+logger = logging.getLogger()
 
-pids = get_pid(desiredApp)
+logger.setLevel(logging.DEBUG)
+formatter = logging.Formatter(
+  '%(asctime)s %(levelname)s %(name)s: %(message)s', '%b %d %H:%M:%S')
+stdout = logging.StreamHandler(sys.stdout)
+stdout.setFormatter(formatter)
+logger.addHandler(stdout)
 
-if pids:
-    print "Monitoring %s, with PIDs: %s" % (desiredApp, pids) 
 
-try:
-    last_active_app = None
-    stop = True
-    while True:
-        active_app = NSWorkspace.sharedWorkspace().activeApplication()
-        if last_active_app != active_app['NSApplicationName']:
-            last_active_app = active_app['NSApplicationName']
-            print "Currently focused on", last_active_app
-            if last_active_app == desiredApp:
-                stop = True
-                if pids:
-                    print "Continuing", desiredApp
-                    for pid in pids:
-                        os.kill(pid, signal.SIGCONT)
-            elif stop:
-                stop = False
-                if pids:
-                    print "Stopping", desiredApp
-                    for pid in pids:
-                        os.kill(pid, signal.SIGSTOP)
-        sleep(1)
-except KeyboardInterrupt:
-    print '\nExiting script'
-    if pids:
-        print '\nResuming %s' % desiredApp
-        for pid in pids:
-            os.kill(pid, signal.SIGCONT)
-    sys.exit()
+def get_pids(app):
+  """Returns list of all process IDs for given application.
+  """
+  if not app:
+    return []
+  pid = app['NSApplicationProcessIdentifier']
+  pids = [pid]
+  try:
+    pids += map(int, subprocess.check_output(['pgrep', '-P %s' % pid]).split())
+  except subprocess.CalledProcessError:
+    pass
+  return pids
+
+
+SUSPENDED = set()
+
+
+def main():
+  prev_app = None
+
+  while True:
+    app = NSWorkspace.sharedWorkspace().activeApplication()
+    if prev_app is None:
+      prev_app = app
+    if app != prev_app:
+      pids = get_pids(prev_app)
+      logger.debug('Suspending %s (%s)', pids, prev_app['NSApplicationName'])
+      map(SUSPENDED.add, pids)
+      map(lambda x: os.kill(x, signal.SIGSTOP), pids)
+
+      pids = get_pids(app)
+      logger.debug('Resuming %s (%s)', pids, app['NSApplicationName'])
+      map(SUSPENDED.discard, pids)
+      map(lambda x: os.kill(x, signal.SIGCONT), pids)
+      # sometimes it won't work from the first time
+      map(lambda x: os.kill(x, signal.SIGCONT), pids)
+      prev_app = app
+    time.sleep(0.5)
+
+
+if __name__ == '__main__':
+  try:
+    main()
+  except KeyboardInterrupt:
+    map(lambda x: os.kill(x, signal.SIGCONT), SUSPENDED)


### PR DESCRIPTION
Just an idea – suspend all applications which are not active, but been in focus before (so only the ones with "windows"). This way you don't need to type anything manually and just use this script on startup (or maybe only on battery power). It suspends all PIDs, including children, which is important for Chrome and Electron like apps.

Good job anyway, I didn't know about AppKit and I used to use `killall -STOP "Google Chrome Helper"` manually a lot.

This one works fine for suspending Chrome and Atom for me.